### PR TITLE
Some changes

### DIFF
--- a/tails/rust.tail.dockerfile
+++ b/tails/rust.tail.dockerfile
@@ -9,8 +9,8 @@ WORKDIR /bot
 ARG BINARY_NAME=bot
 ENV BINARY_NAME=${BINARY_NAME}
 RUN cargo build --release --bin ${BINARY_NAME}
-
-### Check signature of Google's distroless debian image
+RUN cp target/release/${BINARY_NAME} /usr/local/bin/bot
+RUN rm -rf /bot/target
 
 FROM alpine:latest AS verify
 COPY --from=cosign-bin /ko-app/cosign /usr/local/bin/cosign
@@ -26,5 +26,5 @@ ENV BINARY_NAME=${BINARY_NAME}
 WORKDIR /bot
 
 COPY --from=builder /bot /bot
-COPY --from=builder /bot/target/release/${BINARY_NAME} /usr/local/bin/bot
+COPY --from=builder /usr/local/bin/bot /usr/local/bin/bot
 CMD ["/usr/local/bin/bot"]

--- a/tails/rust.tail.dockerfile
+++ b/tails/rust.tail.dockerfile
@@ -1,10 +1,26 @@
+# syntax=docker.io/docker/dockerfile:1.7-labs
+# ^ Required to support --exclude in COPY
+
 ARG LANGUAGE_VERSION=1.84.0
-FROM rust:${LANGUAGE_VERSION}-bookworm
+FROM rust:${LANGUAGE_VERSION}-bookworm as builder
 COPY repo /bot
 WORKDIR /bot
 
 ARG BINARY_NAME=bot
 ENV BINARY_NAME=${BINARY_NAME}
+RUN cargo build --release --bin ${BINARY_NAME}
 
-RUN cargo build --release --target-dir /bot/bin --bin ${BINARY_NAME}
-CMD ./bin/release/${BINARY_NAME}
+### Check signature of Google's distroless debian image
+FROM ghcr.io/sigstore/cosign/cosign:v2.4.1
+RUN cosign verify gcr.io/distroless/cc-debian12 --certificate-oidc-issuer https://accounts.google.com --certificate-identity keyless@distroless.iam.gserviceaccount.com
+
+FROM gcr.io/distroless/cc-debian12 
+
+ARG BINARY_NAME=bot
+ENV BINARY_NAME=${BINARY_NAME}
+
+WORKDIR /bot
+
+COPY --from=builder --exclude=target --exclude=.git /bot /bot
+COPY --from=builder /bot/target/release/${BINARY_NAME} /usr/local/bin/bot
+CMD ["/usr/local/bin/bot"]

--- a/tails/rust.tail.dockerfile
+++ b/tails/rust.tail.dockerfile
@@ -1,4 +1,7 @@
 ARG LANGUAGE_VERSION=1.84.0
+
+FROM ghcr.io/sigstore/cosign/cosign:v2.4.1 AS cosign-bin
+
 FROM rust:${LANGUAGE_VERSION}-bookworm as builder
 COPY repo /bot
 WORKDIR /bot
@@ -8,10 +11,14 @@ ENV BINARY_NAME=${BINARY_NAME}
 RUN cargo build --release --bin ${BINARY_NAME}
 
 ### Check signature of Google's distroless debian image
-FROM ghcr.io/sigstore/cosign/cosign:v2.4.1
-RUN cosign verify gcr.io/distroless/cc-debian12 --certificate-oidc-issuer https://accounts.google.com --certificate-identity keyless@distroless.iam.gserviceaccount.com
 
-FROM gcr.io/distroless/cc-debian12 
+FROM alpine:latest AS verify
+COPY --from=cosign-bin /ko-app/cosign /usr/local/bin/cosign
+RUN cosign verify gcr.io/distroless/cc-debian12\
+    --certificate-oidc-issuer https://accounts.google.com \
+    --certificate-identity keyless@distroless.iam.gserviceaccount.com
+
+FROM gcr.io/distroless/cc-debian12
 
 ARG BINARY_NAME=bot
 ENV BINARY_NAME=${BINARY_NAME}

--- a/tails/rust.tail.dockerfile
+++ b/tails/rust.tail.dockerfile
@@ -1,6 +1,3 @@
-# syntax=docker.io/docker/dockerfile:1.7-labs
-# ^ Required to support --exclude in COPY
-
 ARG LANGUAGE_VERSION=1.84.0
 FROM rust:${LANGUAGE_VERSION}-bookworm as builder
 COPY repo /bot
@@ -21,6 +18,6 @@ ENV BINARY_NAME=${BINARY_NAME}
 
 WORKDIR /bot
 
-COPY --from=builder --exclude=target --exclude=.git /bot /bot
+COPY --from=builder /bot /bot
 COPY --from=builder /bot/target/release/${BINARY_NAME} /usr/local/bin/bot
 CMD ["/usr/local/bin/bot"]

--- a/tails/rust.tail.dockerfile
+++ b/tails/rust.tail.dockerfile
@@ -1,0 +1,10 @@
+ARG LANGUAGE_VERSION=1.84.0
+FROM rust:${LANGUAGE_VERSION}-bookworm
+COPY repo /bot
+WORKDIR /bot
+
+ARG BINARY_NAME=bot
+ENV BINARY_NAME=${BINARY_NAME}
+
+RUN cargo build --release --target-dir /bot/bin --bin ${BINARY_NAME}
+CMD ./bin/release/${BINARY_NAME}

--- a/tails/rust.tail.toml
+++ b/tails/rust.tail.toml
@@ -1,0 +1,17 @@
+[tail]
+name = "rust"
+display_name = "Rust (stable)"
+description = "Rust build and run container, glibc"
+last_modified = 2025-01-13
+
+[config.binary_name]
+type = "string"
+default = "bot"
+arg = "BINARY_NAME"
+description = "Name of the binary package to build"
+
+[config.language_version]
+type = "string"
+default = "1.84.0"
+arg = "LANGUAGE_VERSION"
+description = "Rust version to use."


### PR DESCRIPTION
- Fixed image verification (previous image does not have a shell?)
- Removed --exclude in favor of `rm -rf`

You can take these and modify them after. :)